### PR TITLE
(#3) docs: add troubleshooting guides for mac-ops, win-ops, ai-heatmap

### DIFF
--- a/ai-heatmap-npx-cache.md
+++ b/ai-heatmap-npx-cache.md
@@ -1,0 +1,100 @@
+# ai-heatmap npx 캐시로 인해 최신 버전이 적용되지 않는 트러블슈팅
+
+> 날짜: 2026-03-01
+> 프로젝트: [ai-heatmap](https://github.com/seunggabi/ai-heatmap)
+> 관련 버전: v1.17.2 ~
+
+---
+
+## 증상
+
+`npx ai-heatmap@latest update` 또는 `npx ai-heatmap@latest deploy`를 실행했는데 새 버전에서 수정된 버그가 여전히 발생함. npm에 최신 버전이 배포되어 있음에도 변경사항이 반영되지 않음.
+
+```bash
+$ npx ai-heatmap@latest --version
+1.17.1   # ← 최신 버전(1.17.5)이 아닌 캐시된 구버전 실행
+```
+
+---
+
+## 원인: npx 캐시
+
+### 문제
+
+`npx`는 한 번 다운로드한 패키지를 로컬 캐시(`~/.npm/_npx/`)에 저장하고, 이후 실행 시 npm 레지스트리를 새로 확인하지 않고 **캐시된 버전을 그대로 사용**함.
+
+`@latest` 태그를 명시해도 캐시가 있으면 캐시 우선 사용.
+
+```bash
+# 캐시 확인
+ls ~/.npm/_npx/
+# → 이미 ai-heatmap이 캐시되어 있음
+
+# 실제 최신 버전 확인
+npm view ai-heatmap version
+# → 1.17.5
+
+# npx 실행 (캐시에서 가져옴)
+npx ai-heatmap@latest --version
+# → 1.17.1  ← 캐시된 구버전
+```
+
+---
+
+## 수정
+
+### 실행 전 npx 캐시 삭제
+
+```bash
+npx clear-npx-cache --yes && npx ai-heatmap@latest update
+```
+
+```bash
+npx clear-npx-cache --yes && npx ai-heatmap@latest deploy
+```
+
+`--yes` 플래그: 삭제 확인 프롬프트를 건너뜀 (cron 자동화 환경에서 필수).
+
+### cron에 적용
+
+```bash
+# BEFORE: 캐시 삭제 없이 실행
+0 */6 * * * npx ai-heatmap@latest update
+
+# AFTER: 캐시 삭제 후 실행
+0 */6 * * * npx clear-npx-cache --yes && npx ai-heatmap@latest update
+```
+
+---
+
+## 검증 방법
+
+```bash
+# 1. 캐시 삭제
+npx clear-npx-cache --yes
+
+# 2. 최신 버전으로 실행되는지 확인
+npx ai-heatmap@latest --version
+# ✅ 1.17.5 (최신 버전)
+```
+
+---
+
+## 참고
+
+- npx 캐시 위치: `~/.npm/_npx/`
+- `clear-npx-cache` 패키지: https://www.npmjs.com/package/clear-npx-cache
+- 업그레이드 후 버그가 재현된다면 항상 캐시 삭제 후 재시도
+
+---
+
+## 관련 PR
+
+| 버전 | PR | 내용 |
+|------|----|------|
+| v1.17.2 | #82 | Upgrade 섹션에 npx 캐시 트러블슈팅 안내 추가 |
+| v1.17.3 | #84 | cron 업데이트 예시에 캐시 삭제 추가 |
+| v1.17.4 | #86 | init.mjs 생성 README의 cron 예시에 캐시 삭제 추가 |
+| v1.17.5 | #88 | deploy 명령 실행 전 캐시 삭제 안내 추가 |
+| v1.17.6 | #90 | 모든 `ai-heatmap@latest` 명령 앞에 캐시 삭제 추가 |
+| v1.17.7 | #98 | `--yes` 플래그 추가 (프롬프트 자동 건너뜀) |

--- a/mac-ops-homebrew-wrong-version.md
+++ b/mac-ops-homebrew-wrong-version.md
@@ -1,0 +1,122 @@
+# mac-ops Homebrew 설치 시 잘못된 버전 표시 트러블슈팅
+
+> 날짜: 2026-03-01
+> 프로젝트: [mac-ops](https://github.com/seunggabi/mac-ops)
+> 관련 버전: v1.2.0
+
+---
+
+## 증상
+
+Homebrew로 설치한 `mac-ops`의 버전을 확인하면 실제 버전(`v1.2.0`)이 아닌 엉뚱한 버전이 출력됨.
+
+```bash
+$ mac-ops version
+v5.0.14   # ← 잘못된 버전 (Homebrew 자체 버전)
+```
+
+개발 환경(git clone)에서는 정상적으로 표시됨.
+
+```bash
+$ ./bin/mac-ops version
+v1.2.0   # ← 정상
+```
+
+---
+
+## 원인: `git describe`의 부모 디렉토리 탐색
+
+### 문제
+
+`bin/mac-ops`에서 버전을 출력할 때 `git describe --tags`를 사용했음.
+
+```bash
+# BEFORE
+VERSION=$(git describe --tags --abbrev=0 2>/dev/null)
+echo "$VERSION"
+```
+
+Homebrew로 설치하면 `.git` 디렉토리가 없음. `git describe`는 `.git`을 찾을 때까지 **부모 디렉토리를 재귀적으로 탐색**하는데, Homebrew 자체가 git 저장소이므로 `/opt/homebrew/.git`을 발견하고 Homebrew의 최신 태그(`v5.0.14` 등)를 반환함.
+
+```
+/opt/homebrew/
+├── .git/               ← Homebrew 자체 git 저장소
+└── Cellar/
+    └── mac-ops/
+        └── 1.2.0/
+            └── bin/
+                └── mac-ops   ← 여기서 git describe 실행 시 /opt/homebrew/.git 탐색
+```
+
+### 오류 흐름
+
+```
+git describe 실행
+  → .git 없음 (현재 디렉토리)
+  → 부모 디렉토리 탐색
+  → /opt/homebrew/.git 발견
+  → Homebrew 태그 반환 (v5.0.14)
+```
+
+---
+
+## 수정
+
+### 접근 방식
+
+`.git` 존재 여부를 먼저 확인하고, 없으면 `VERSION` 파일에서 읽도록 fallback 추가.
+
+```bash
+# AFTER: bin/mac-ops
+if git rev-parse --git-dir > /dev/null 2>&1; then
+  # 개발 환경: git describe 사용
+  VERSION=$(git describe --tags --abbrev=0 2>/dev/null)
+else
+  # 배포 환경 (Homebrew 등): VERSION 파일 사용
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  VERSION=$(cat "$SCRIPT_DIR/../VERSION" 2>/dev/null)
+fi
+echo "${VERSION:-unknown}"
+```
+
+### VERSION 파일 추가
+
+```
+# VERSION
+1.2.0
+```
+
+### 릴리즈 워크플로우에서 tarball에 VERSION 파일 포함
+
+```yaml
+# .github/workflows/release.yml
+- name: Patch tarball with VERSION file
+  run: |
+    echo "${{ steps.tag.outputs.version }}" > VERSION
+    tar -czf mac-ops.tar.gz bin lib VERSION
+```
+
+---
+
+## 검증 방법
+
+```bash
+# git 없는 환경 시뮬레이션
+cd /tmp/test
+cp -r /path/to/mac-ops/{bin,lib,VERSION} .
+./bin/mac-ops version
+# ✅ v1.2.0 (VERSION 파일에서 읽음)
+
+# git 있는 환경
+cd /path/to/mac-ops
+./bin/mac-ops version
+# ✅ v1.2.0 (git describe에서 읽음)
+```
+
+---
+
+## 관련 PR
+
+| 버전 | PR | 내용 |
+|------|----|------|
+| v1.2.1 | #29 | Homebrew 설치 시 잘못된 버전 표시 수정 |

--- a/win-ops-scheduled-task-powershell-window.md
+++ b/win-ops-scheduled-task-powershell-window.md
@@ -1,0 +1,103 @@
+# win-ops Task Scheduler 실행 시 PowerShell 창이 닫히지 않는 트러블슈팅
+
+> 날짜: 2026-03-01
+> 프로젝트: [win-ops](https://github.com/seunggabi/win-ops)
+> 관련 버전: v0.7.7 → v0.7.8
+
+---
+
+## 증상
+
+win-ops를 Task Scheduler에 등록한 후 자동 실행될 때마다 PowerShell 창이 화면에 나타나 그대로 남아 있음.
+
+```
+[작업 스케줄러 실행 시]
+- PowerShell 창이 열림
+- 스크립트 실행 완료 후에도 창이 닫히지 않음
+- 매 실행마다 반복 발생
+```
+
+수동으로 실행하면 정상이나, Task Scheduler 자동 실행 시에만 발생.
+
+---
+
+## 원인: pwsh 실행 인수에 `-WindowStyle Hidden` 미적용
+
+### 문제
+
+`WinOpsTask.xml` (작업 스케줄러 등록 XML)의 `Arguments` 항목과 `TaskScheduler.psm1`의 pwsh 호출 부분에 창 숨김 옵션이 없었음.
+
+```xml
+<!-- BEFORE: WinOpsTask.xml -->
+<Arguments>-ExecutionPolicy Bypass -File "C:\win-ops\win-ops.ps1"</Arguments>
+```
+
+```powershell
+# BEFORE: TaskScheduler.psm1
+$action = New-ScheduledTaskAction -Execute "pwsh" `
+    -Argument "-ExecutionPolicy Bypass -File `"$scriptPath`""
+```
+
+Task Scheduler는 기본적으로 새 콘솔 창을 생성하며, `-WindowStyle Hidden`이 없으면 창이 그대로 화면에 표시됨.
+
+---
+
+## 수정
+
+### `-WindowStyle Hidden -NonInteractive` 추가
+
+```xml
+<!-- AFTER: WinOpsTask.xml -->
+<Arguments>-WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File "C:\win-ops\win-ops.ps1"</Arguments>
+```
+
+```powershell
+# AFTER: TaskScheduler.psm1
+$action = New-ScheduledTaskAction -Execute "pwsh" `
+    -Argument "-WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File `"$scriptPath`""
+```
+
+| 옵션 | 역할 |
+|------|------|
+| `-WindowStyle Hidden` | 콘솔 창을 생성하지 않음 |
+| `-NonInteractive` | 사용자 입력 프롬프트 비활성화 (자동화 환경에서 hang 방지) |
+
+### 재설치 시 자동 업데이트 처리
+
+기존에는 이미 등록된 작업 스케줄러 태스크가 있을 때 `-InstallScheduledTask` 플래그를 명시해야 업데이트됐음. 수정 후 `install.ps1`이 기존 태스크를 자동 감지해 업데이트.
+
+```powershell
+# AFTER: install.ps1
+$existingTask = Get-ScheduledTask -TaskName "WinOps" -ErrorAction SilentlyContinue
+if ($existingTask) {
+    # 기존 태스크 자동 업데이트 (플래그 없이도 동작)
+    Unregister-ScheduledTask -TaskName "WinOps" -Confirm:$false
+}
+# 태스크 새로 등록
+Register-ScheduledTask ...
+```
+
+---
+
+## 검증 방법
+
+```powershell
+# 1. 태스크 등록
+.\install.ps1
+
+# 2. Arguments에 -WindowStyle Hidden 포함 여부 확인
+(Get-ScheduledTask -TaskName "WinOps").Actions.Arguments
+# ✅ -WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File "..."
+
+# 3. 태스크 수동 실행 후 창 미표시 확인
+Start-ScheduledTask -TaskName "WinOps"
+# ✅ PowerShell 창 미표시
+```
+
+---
+
+## 관련 PR
+
+| 버전 | PR | 내용 |
+|------|----|------|
+| v0.7.8 | #39 | Task Scheduler 실행 시 PowerShell 창 숨김 처리 |


### PR DESCRIPTION
## Summary
Add 3 new troubleshooting guides based on real bug fixes from public projects.

## Changes
- `mac-ops-homebrew-wrong-version.md`: `git describe` picks up parent Homebrew repo tag when .git is absent
- `win-ops-scheduled-task-powershell-window.md`: PowerShell window stays open during Task Scheduler execution due to missing `-WindowStyle Hidden`
- `ai-heatmap-npx-cache.md`: `npx ai-heatmap@latest` runs cached old version instead of latest

Closes #3